### PR TITLE
add JVX_FORCE_INLINE define to force the compiler to inline a function

### DIFF
--- a/sources/jvxLibraries/jvx-system-min/include/platform/common_ux/jvx_system_helpers_ux.h
+++ b/sources/jvxLibraries/jvx-system-min/include/platform/common_ux/jvx_system_helpers_ux.h
@@ -11,6 +11,13 @@
 
 #define JVX_RESTRICT /*__restrict*/
 #define JVX_STATIC_INLINE static inline
+#if defined(__GNUC__) || defined(__clang__)
+#define JVX_FORCE_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define JVX_FORCE_INLINE __forceinline
+#else
+#define JVX_FORCE_INLINE
+#endif
 
 #define JVX_PRINTF_S printf_s
 #define JVX_SPRINTF_S sprintf_s

--- a/sources/jvxLibraries/jvx-system-min/include/platform/windows/jvx_system_helpers.h
+++ b/sources/jvxLibraries/jvx-system-min/include/platform/windows/jvx_system_helpers.h
@@ -6,6 +6,13 @@
 
 #define JVX_RESTRICT /*__restrict*/
 #define STATIC_INLINE static inline 
+#if defined(__GNUC__) || defined(__clang__)
+#define JVX_FORCE_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define JVX_FORCE_INLINE __forceinline
+#else
+#define JVX_FORCE_INLINE
+#endif
 
 #define JVX_PRINTF_S printf_s
 #define JVX_SPRINTF_S sprintf_s


### PR DESCRIPTION
`JVX_FORCE_INLINE` ist damit für Windows und common_ux definiert. Funktioniert für GCC, Clang und MSVC. Für alle anderen wird es ignoriert.