### PR TITLE
make prepareModules-linux.sh script work without the aqt wrapper binary

### DIFF
--- a/sources/jvxLibraries/third_party/web/qt/prepareModules-linux.sh
+++ b/sources/jvxLibraries/third_party/web/qt/prepareModules-linux.sh
@@ -6,5 +6,5 @@
 # aqt list-qt linux desktop --arch 5.15.2
 if [ ! -d "qt/$1/$2" ]; then
 	echo aqt install-qt linux desktop $1 $2 -O qt
-	aqt install-qt linux desktop $1 $2 -O qt
+	python3 -m aqt install-qt linux desktop $1 $2 -O qt
 fi


### PR DESCRIPTION
Depending on the distribution, the aqt binary is not installed or the path is not set correctly. Calling the python interpreter instead always works.