### PR TITLE
boost prepareModule: switch from p7zip to 7zip binary

### DIFF
--- a/sources/jvxLibraries/third_party/web/boost/prepareModules-glnx.sh
+++ b/sources/jvxLibraries/third_party/web/boost/prepareModules-glnx.sh
@@ -7,9 +7,9 @@ if [ ! -d "boost" ]; then
 		curl -kLSs https://boostorg.jfrog.io/artifactory/main/release/1.70.0/binaries/boost_1_70_0-unsupported-bin-msvc-all-32-64.7z -o boost-1.70.0.7z
 	fi 
 
-	# We need to "sudo apt install p7zip-full"
+	# We need to "sudo apt install 7zip"
 	echo "2) Extracting boost binary package"
-	7z x boost-1.70.0.7z
+	7zz x boost-1.70.0.7z
 	
 	echo "3) Renaming boost folder"
 	mv boost_1_70_0 boost


### PR DESCRIPTION
The p7zip binary has different names on different distros. For example, on Ubuntu 22.04 the `7z` binary does not exist. The official package's binary should always be called `7zz`. Also the `p7zip` package is (mostly) unmaintained.