### PR TITLE
add Tracy Profiler to the build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ else()
 endif()
 
 # Check build type
-if(NOT ${CMAKE_BUILD_TYPE} MATCHES "^(Debug|Release)$")
+if(NOT ${CMAKE_BUILD_TYPE} MATCHES "^(Debug|Release|RelWithDebInfo)$")
   message(FATAL_ERROR "Unknown build type '${CMAKE_BUILD_TYPE}' given")
 endif()
 

--- a/cmake/common_local_exe_foot.cmake
+++ b/cmake/common_local_exe_foot.cmake
@@ -23,6 +23,16 @@ if(NOT INSTALL_COMPONENT)
 endif()
 
 ###
+# Tracy Profiler
+###
+if(NOT JVX_COMPILE_BUILDTOOLS)
+  # add it even it JVX_USE_TRACY is not set because
+  # the tracy target is added as interface library
+  # to set the include dirs then
+  set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} tracy)
+endif()
+
+###
 # QT support
 ###
 set(JVX_ENABLE_QT FALSE)

--- a/cmake/common_local_lib_foot.cmake
+++ b/cmake/common_local_lib_foot.cmake
@@ -20,6 +20,16 @@ else()
   set(INSTALL_COMPONENT "release")
 endif()
 
+###
+# Tracy Profiler
+###
+if(NOT JVX_COMPILE_BUILDTOOLS)
+  # add it even it JVX_USE_TRACY is not set because
+  # the tracy target is added as interface library
+  # to set the include dirs then
+  set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} tracy)
+endif()
+
 if(JVX_USE_AVX)
   if(C_AVX_FOUND)
       set(ADDITIONAL_C_FLAGS "${ADDITIONAL_C_FLAGS} ${C_AVX_FLAGS}")

--- a/cmake/fragments/options.cmake
+++ b/cmake/fragments/options.cmake
@@ -71,6 +71,7 @@ option(JVX_USE_MFVIDEO "Compile with support for Windows MF Video - Windows only
 option(JVX_USE_V4L2VIDEO "Compile with support for Video4Linux2 - Linux only" OFF)
 option(JVX_USE_CBMT "Use c-bitmap library" OFF)
 option(JVX_USE_RUST "Use code in Rust" OFF)
+option(JVX_USE_TRACY "Build the Tracy Profiler client into the applications" OFF)
 set(JVXRT_SUBMODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/sources/sub-projects" CACHE STRING "Path to submodule folder")
 set(JVXRT_SUBMODULE_FLUTTER_PATH "${CMAKE_CURRENT_SOURCE_DIR}/flutter" CACHE STRING "Path to flutter submodules")
 

--- a/cmake/fragments/thrdparty-early.cmake
+++ b/cmake/fragments/thrdparty-early.cmake
@@ -33,3 +33,15 @@ if(JVX_USE_BOOST)
     set(JVX_BASE_3RDPARTY_LIBS ${JVX_BASE_3RDPARTY_LIBS}
       ${JVX_SUBPRODUCT_ROOT}/sources/jvxLibraries/third_party/web/boost)
 endif()
+
+if(JVX_USE_TRACY)
+  if(NOT CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo")
+    message(WARNING "Tracy Profiler should be used with the RelWithDebInfo build profile")
+  endif()
+endif()
+# We download Tracy even if JVX_USE_TRACY is not set so Tracy.hpp is avaible
+# with the empty macros. This avoids all the `#ifdef TRACY_ENABLE .. #endif` blocks.
+# The library is not built or linked in that case. It's only a cmake interface library
+# to set the include directory.
+set(JVX_BASE_3RDPARTY_LIBS ${JVX_BASE_3RDPARTY_LIBS}
+  ${JVX_SUBPRODUCT_ROOT}/sources/jvxLibraries/third_party/git/tracy)

--- a/cmake/linux.cmake
+++ b/cmake/linux.cmake
@@ -54,6 +54,11 @@ set(JVX_CMAKE_LINKER_FLAGS_SHARED "-Wl,--no-undefined -shared ${JVX_COMPILE_FLAG
 set(WHOLE_ARCHIVE "-Wl,--whole-archive")
 set(NO_WHOLE_ARCHIVE "-Wl,--no-whole-archive")
 
+# set compiler/linker flags for RelWithDebInfo according to Tracy Profiler documentation
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -fno-omit-frame-pointer")
+set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O2 -g -fno-omit-frame-pointer")
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "-Wl,-O1 -rdynamic")
+
 if(JVX_GCC_LINKER_SYMBOLIC)
   # The following line to allow -fPIC linkage of ffmpeg
   # https://github.com/microsoft/vcpkg/issues/17292

--- a/sources/jvxComponents/jvxVideoNodes/jvxViNCameraConvert/src/CayfViNCameraConvert_process.cpp
+++ b/sources/jvxComponents/jvxVideoNodes/jvxViNCameraConvert/src/CayfViNCameraConvert_process.cpp
@@ -3,6 +3,8 @@
 
 #include <opencv2/imgproc.hpp>
 
+#include <tracy/Tracy.hpp>
+
 jvxErrorType
 CayfViNCameraConvert::prepare_connect_icon(JVX_CONNECTION_FEEDBACK_TYPE(fdb))
 {
@@ -102,6 +104,7 @@ CayfViNCameraConvert::prepare_connect_icon(JVX_CONNECTION_FEEDBACK_TYPE(fdb))
 jvxErrorType
 CayfViNCameraConvert::process_buffers_icon(jvxSize mt_mask, jvxSize idx_stage)
 {
+	ZoneScopedN("CameraConvert");
 	if (zeroCopyBuffering_rt)
 	{
 		return fwd_process_buffers_icon(mt_mask, idx_stage);

--- a/sources/jvxComponents/jvxVideoNodes/jvxViNMixer/src/CjvxViNMixer.cpp
+++ b/sources/jvxComponents/jvxVideoNodes/jvxViNMixer/src/CjvxViNMixer.cpp
@@ -4,6 +4,8 @@
 #include "cbmp.h"
 #endif
 
+#include <tracy/Tracy.hpp>
+
 #ifdef JVX_PROJECT_NAMESPACE
 namespace JVX_PROJECT_NAMESPACE {
 #endif
@@ -803,6 +805,7 @@ CjvxViNMixer::activate_connectors()
 				else
 				{
 					CjvxViNMixer_genpcg::expose.lost_frames.value++;
+					TracyMessageLC("CjvxViNMixer: Frame lost", tracy::Color::Red);
 				}
 
 				if (buf->specific.the2DFieldBuffer_full.report_triggerf)

--- a/sources/jvxLibraries/third_party/git/tracy/CMakeLists.txt
+++ b/sources/jvxLibraries/third_party/git/tracy/CMakeLists.txt
@@ -1,0 +1,36 @@
+set(PROJECT_NAME tracy)
+
+# We cannot use common_local_lib_{head,foot}.cmake here because it leads to cyclic dependencies
+# as Tracy is used globally, in every lib and every binary. This is the only way to be able
+# to profile all of the code.
+
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/tracy)
+	message("Tracy Profiler sub project not available. Starting script to download it.")
+	execute_process(COMMAND ${mysh} -c "cd ${CMAKE_CURRENT_SOURCE_DIR} ; ./prepareModules.sh; exit")
+	message("Tracy Profiler installation complete.")
+endif()
+
+set(TRACY_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/tracy/public/" CACHE INTERNAL "Tracy Profiler client include dirs")
+
+set(LOCAL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tracy/public/TracyClient.cpp)
+set(LOCAL_COMPILE_DEFINITIONS "TRACY_ENABLE")
+
+if(JVX_USE_TRACY)
+	add_library(tracy SHARED "${LOCAL_SOURCES}")
+	target_link_libraries(tracy PUBLIC pthread dl)
+	target_compile_definitions(tracy PUBLIC "${LOCAL_COMPILE_DEFINITIONS}")
+	target_include_directories(tracy PUBLIC ${TRACY_INCLUDE_DIRS})
+else()
+	add_library(tracy INTERFACE)
+	target_include_directories(tracy INTERFACE ${TRACY_INCLUDE_DIRS})
+endif()
+
+if(JVX_USE_TRACY AND JVX_SHARED_LIB_TARGET_FOLDER)
+	install(TARGETS tracy
+		RUNTIME DESTINATION ${JVX_SHARED_LIB_TARGET_FOLDER}
+		LIBRARY DESTINATION ${INSTALL_PATH_LIB_SHARED})
+else()
+	install(TARGETS tracy
+		RUNTIME DESTINATION ${INSTALL_PATH_LIB_SHARED}
+		LIBRARY DESTINATION ${INSTALL_PATH_LIB_SHARED})
+endif()

--- a/sources/jvxLibraries/third_party/git/tracy/prepareModules.sh
+++ b/sources/jvxLibraries/third_party/git/tracy/prepareModules.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ ! -d "tracy" ]; then
+	git clone https://github.com/wolfpld/tracy.git
+	cd tracy
+	git checkout v0.11.1
+fi

--- a/sources/sub-projects/ayfstarter/sources/Components/AudioNodes/ayfAuNStarter/src/CayfAuNStarter.cpp
+++ b/sources/sub-projects/ayfstarter/sources/Components/AudioNodes/ayfAuNStarter/src/CayfAuNStarter.cpp
@@ -1,6 +1,8 @@
 #include "jvx.h"
 #include "CayfAuNStarter.h"
 
+#include <tracy/Tracy.hpp>
+
 #ifdef JVX_PROJECT_NAMESPACE
 namespace JVX_PROJECT_NAMESPACE {
 #endif
@@ -113,15 +115,19 @@ CayfAuNStarter::local_prepare_connect_icon(JVX_CONNECTION_FEEDBACK_TYPE(fdb))
 jvxErrorType
 CayfAuNStarter::local_process_buffers_icon(jvxSize mt_mask, jvxSize idx_stage)
 {
+	ZoneScoped; // Create a scoped zone in the Tracy Profiler
 	jvxData** buffers_in = jvx_process_icon_extract_input_buffers<jvxData>(_common_set_icon.theData_in, idx_stage);
 	jvxData** buffers_out = jvx_process_icon_extract_output_buffers<jvxData>(_common_set_ocon.theData_out);
 
+	FrameMarkStart("ayf_starter_process"); // Mark the start of a frame in Tracy Profiler
 	// Involve the c-library for processing
-	return ayf_starter_process(&processing_lib, buffers_in, buffers_out, 
-		_common_set_icon.theData_in->con_params.number_channels, 
+	jvxDspBaseErrorType res = ayf_starter_process(&processing_lib, buffers_in, buffers_out,
+		_common_set_icon.theData_in->con_params.number_channels,
 		_common_set_ocon.theData_out.con_params.number_channels,
 		_common_set_icon.theData_in->con_params.buffersize);
+	FrameMarkEnd("ayf_starter_process"); // Mark the end of a frem in Tracy Profiler
 	
+	return res;
 	// return fwd_process_buffers_icon(mt_mask, idx_stage); <- no longer in use as this call is in template class already
 }
 


### PR DESCRIPTION
When `JVX_USE_TRACY` is set, the Tracy Profiler is built and linked to all libs and executables in AudYoFlo.