### PR TITLE
jvx-dsp-rust: add circbuffer(fft) bindings

### DIFF
--- a/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/ffi.rs
+++ b/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/ffi.rs
@@ -1,0 +1,59 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+use crate::*;
+
+#[repr(C)]
+pub struct Ram {
+    pub field: *const *mut JvxData,
+}
+
+#[repr(C)]
+pub struct JvxCircbuffer {
+    pub length: JvxSize,
+    pub channels: JvxSize,
+    pub idxRead: JvxSize,
+    pub fHeight: JvxSize,
+    pub nUnits: JvxSize, // for SOS IIR filters
+    pub format: JvxDataFormat,
+    pub szElement: JvxSize,
+    pub ram: Ram,
+}
+
+extern "C" {
+    pub fn jvx_circbuffer_allocate(
+        hdlOnReturn: *mut *mut JvxCircbuffer,
+        numberElements: JvxSize,
+        nSections: JvxSize,
+        channels: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_deallocate(hdlReturn: *mut JvxCircbuffer) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_fill(
+        hdl: *mut JvxCircbuffer,
+        toFillWith: JvxData,
+        numberValuesFill: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_write_update(
+        hdl: *mut JvxCircbuffer,
+        fieldFill: *const JvxData,
+        numberValuesFill: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_copy_update_buf2buf(
+        hdl_copyTo: *mut JvxCircbuffer,
+        hdl_copyFrom: *const JvxCircbuffer,
+        numberValuesFill: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_advance_read_index(
+        hdl: *mut JvxCircbuffer,
+        numberValuesRead: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_get_write_phase(
+        hdl: *const JvxCircbuffer,
+        phase: *mut JvxSize,
+    ) -> JvxDspBaseErrorType;
+}

--- a/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/fft/ffi.rs
+++ b/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/fft/ffi.rs
@@ -1,0 +1,53 @@
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+use crate::fft::ffi::*;
+use crate::*;
+use circbuffer::ffi::*;
+
+#[repr(C)]
+pub struct Ram {
+    field_cplx: *const *mut JvxDataCplx,
+}
+
+#[repr(C)]
+pub struct JvxCircbufferFft {
+    circBuffer: JvxCircbuffer,
+
+    fftType: JvxFftToolsCoreFftType,
+    fftSize: JvxFFTSize,
+    fftifft: JvxHandle, //struct jvxFftIfftHandle*;
+
+    length_cplx: JvxSize,
+}
+
+extern "C" {
+    // jvx_circbuffer_allocate_global_fft_ifft is equivalent to jvx_create_fft_ifft_global
+    // jvx_circbuffer_destroy_global_fft_ifft is equivalent to jvx_circbuffer_destroy_global_fft_ifft
+
+    pub fn jvx_circbuffer_allocate_fft_ifft(
+        hdlOnReturn: *mut *mut JvxCircbufferFft,
+        hdl_global_fft: *const JvxFFTGlobal,
+        fftType: JvxFftToolsCoreFftType,
+        fftSize: JvxFFTSize,
+        preserveInput: JvxCBool,
+        nChannels: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_deallocate_fft_ifft(
+        hdlReturn: *const JvxCircbufferFft,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_access_cplx_fft_ifft(
+        hdl: *const JvxCircbufferFft,
+        outPtr: *const *mut JvxDataCplx,
+        outLen: *mut JvxSize,
+        idx: JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_get_write_phase_fft_ifft(
+        hdl: *const JvxCircbufferFft,
+        phase: *mut JvxSize,
+    ) -> JvxDspBaseErrorType;
+
+    pub fn jvx_circbuffer_process_fft_ifft(hdl: *mut JvxCircbufferFft) -> JvxDspBaseErrorType;
+}

--- a/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/fft/mod.rs
+++ b/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/fft/mod.rs
@@ -1,0 +1,72 @@
+use crate::fft::*;
+use crate::*;
+use alloc::rc::Rc;
+use alloc::vec::Vec;
+
+pub mod ffi;
+
+pub struct CircbufferFft {
+    _global: Rc<FftFactory>,
+    hdl: *mut ffi::JvxCircbufferFft,
+}
+
+impl CircbufferFft {
+    pub fn access_cplx(&self, out: &mut [&mut [JvxDataCplx]], idx: JvxSize) -> Result<JvxSize> {
+        let out_ptrs: Vec<*mut JvxDataCplx> = out.iter_mut().map(|x| x.as_mut_ptr()).collect();
+        let mut out_len: JvxSize = 0;
+        let res = unsafe {
+            ffi::jvx_circbuffer_access_cplx_fft_ifft(self.hdl, out_ptrs.as_ptr(), &mut out_len, idx)
+        };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(out_len),
+            err => Err(err),
+        }
+    }
+
+    pub fn get_write_phase(&self) -> Result<JvxSize> {
+        let mut phase: JvxSize = 0;
+        let res = unsafe { ffi::jvx_circbuffer_get_write_phase_fft_ifft(self.hdl, &mut phase) };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(phase),
+            err => Err(err),
+        }
+    }
+
+    pub fn process(&mut self) -> Result<()> {
+        let res = unsafe { ffi::jvx_circbuffer_process_fft_ifft(self.hdl) };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(()),
+            err => Err(err),
+        }
+    }
+}
+
+impl FftFactory {
+    // TODO implement external buffer version
+    pub fn new_circbuffer_fft(
+        self: &Rc<Self>,
+        fft_type: JvxFftToolsCoreFftType,
+        size: FftSize,
+        preserve_input: JvxCBool,
+        n_channels: JvxSize,
+    ) -> Result<CircbufferFft> {
+        let mut hdl: *mut ffi::JvxCircbufferFft = core::ptr::null_mut();
+        let res = unsafe {
+            ffi::jvx_circbuffer_allocate_fft_ifft(
+                &mut hdl,
+                self.hdl,
+                fft_type,
+                size.into(),
+                preserve_input,
+                n_channels,
+            )
+        };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(CircbufferFft {
+                _global: Rc::clone(self),
+                hdl,
+            }),
+            err => Err(err),
+        }
+    }
+}

--- a/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/mod.rs
+++ b/sources/jvxLibraries/jvx-dsp-rust/src/circbuffer/mod.rs
@@ -1,0 +1,83 @@
+use crate::*;
+
+pub mod ffi;
+pub mod fft;
+
+pub struct Circbuffer {
+    hdl: *mut ffi::JvxCircbuffer,
+}
+
+impl Circbuffer {
+    pub fn new(
+        number_elements: JvxSize,
+        number_sections: JvxSize,
+        channels: JvxSize,
+    ) -> Result<Self> {
+        let mut hdl: *mut ffi::JvxCircbuffer = core::ptr::null_mut();
+        let res = unsafe {
+            ffi::jvx_circbuffer_allocate(&mut hdl, number_elements, number_sections, channels)
+        };
+        // TODO maybe fill with 0 to make sure the values are initialized
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(Self { hdl }),
+            err => Err(err),
+        }
+    }
+
+    pub fn fill(&mut self, to_fill_with: JvxData, number_values_fill: JvxSize) -> Result<()> {
+        let res = unsafe { ffi::jvx_circbuffer_fill(self.hdl, to_fill_with, number_values_fill) };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(()),
+            err => Err(err),
+        }
+    }
+
+    pub fn write_update(&mut self, field_fill: &[JvxData]) -> Result<()> {
+        let res = unsafe {
+            ffi::jvx_circbuffer_write_update(self.hdl, field_fill.as_ptr(), field_fill.len())
+        };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(()),
+            err => Err(err),
+        }
+    }
+
+    pub fn copy_update_buf2buf(
+        copy_to: &mut Self,
+        copy_from: &Self,
+        number_values_fill: JvxSize,
+    ) -> Result<()> {
+        let res = unsafe {
+            ffi::jvx_circbuffer_copy_update_buf2buf(copy_to.hdl, copy_from.hdl, number_values_fill)
+        };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(()),
+            err => Err(err),
+        }
+    }
+
+    pub fn advance_read_index(&mut self, number_values_read: JvxSize) -> Result<()> {
+        let res = unsafe { ffi::jvx_circbuffer_advance_read_index(self.hdl, number_values_read) };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(()),
+            err => Err(err),
+        }
+    }
+
+    pub fn get_write_phase(&self) -> Result<JvxSize> {
+        let mut phase: JvxSize = 0;
+        let res = unsafe { ffi::jvx_circbuffer_get_write_phase(self.hdl, &mut phase) };
+        match res {
+            JvxDspBaseErrorType::JVX_NO_ERROR => Ok(phase),
+            err => Err(err),
+        }
+    }
+}
+
+impl Drop for Circbuffer {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::jvx_circbuffer_deallocate(self.hdl);
+        }
+    }
+}

--- a/sources/jvxLibraries/jvx-dsp-rust/src/lib.rs
+++ b/sources/jvxLibraries/jvx-dsp-rust/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate alloc;
 
 pub mod fft;
+pub mod circbuffer;
 
 pub type Error = JvxErrorType;
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
Add safe Rust bindings for (FFT) Circbuffer.